### PR TITLE
Override profile CLI default output format to use JSON

### DIFF
--- a/Blogs/migrate-delimited-files-to-nosql/download-imdb-title-basics.sh
+++ b/Blogs/migrate-delimited-files-to-nosql/download-imdb-title-basics.sh
@@ -8,7 +8,7 @@ mkdir -p tempimdbfiles
 cd tempimdbfiles
 # currently the loop is only looking for one file.
 # You can change the --prefix value to look for a group of files or all the files
-for DOCUMENT in `aws s3api list-objects --bucket imdb-datasets --prefix "documents/v1/current/title.basics.tsv.gz" --request-payer requester --profile $AWSPROFILE | jq -r .Contents[].Key`; do
+for DOCUMENT in `aws s3api list-objects --output json --bucket imdb-datasets --prefix "documents/v1/current/title.basics.tsv.gz" --request-payer requester --profile $AWSPROFILE | jq -r .Contents[].Key`; do
     echo "     downloading $DOCUMENT"
     FILENAME="$(echo $DOCUMENT | sed 's|documents/v1/current/||g')"
     echo " saving to file $FILENAME"


### PR DESCRIPTION
When the default output format is text:
```
1 🍒  migrate-delimited-files-to-nosql/master 05817a7  $ aws configure
AWS Access Key ID [****************]:
AWS Secret Access Key [****************]:
Default region name [ap-southeast-2]:
Default output format [text]:
```

the download script fails:

```
0 🍒  migrate-delimited-files-to-nosql/master 4de075b  $ bash -x download-imdb-title-basics.sh
+ AWSPROFILE=default
+ BUCKETKEY=mybucket/mykey/
+ mkdir -p tempimdbfiles
+ cd tempimdbfiles
++ aws s3api list-objects --bucket imdb-datasets --prefix documents/v1/current/title.basics.tsv.gz --request-payer requester --profile default
++ jq -r '.Contents[].Key'
parse error: Invalid numeric literal at line 2, column 0
```

Adding the option `--output json` fixes the issue..