### PR TITLE
Update README.md

### DIFF
--- a/Blogs/Automate table mappings JSON creation/README.md
+++ b/Blogs/Automate table mappings JSON creation/README.md
@@ -10,17 +10,17 @@ Example:
 Lets assume folder location "/Users/TestUser/CSV_Files_For_DMS" contains two files named include_tables.csv and exclude_tables.csv.
 
 The content of include_tables.csv is:
-HR,EMPLOYEES
-HR,DEPARTMENTS
-HR,JOBS
-HR,LOCATIONS
+HR,EMPLOYEES 
+HR,DEPARTMENTS 
+HR,JOBS 
+HR,LOCATIONS 
 HR,REGIONS
 
 The content of exclude_tables.csv is:
-HR,EMPLOYEES_CHG_LOG
-HR,DEPARTMENTS_TEMP
-HR,JOBS_HISTORY
-HR,LOCATIONS_ARCHIVE
+HR,EMPLOYEES_CHG_LOG 
+HR,DEPARTMENTS_TEMP 
+HR,JOBS_HISTORY 
+HR,LOCATIONS_ARCHIVE 
 HR,REGIONS_BACKUP
 
 When you run this python program, provide the input as "/Users/TestUser/CSV_Files_For_DMS" when asked for the folder location.


### PR DESCRIPTION
Making the line items of include* and exclude* files on individual lines.

*In the current version in non-editable mode all the line items show up on a same line with just space separated. Trying to make them show up on different lines.*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
